### PR TITLE
recordedfuture: feature - Adding the ability to ingest a smaller more relevant scope of artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **on_poll_alert_ruleids** |  optional  | string | Comma-separated list of alert rule IDs
 **on_poll_alert_severity** |  optional  | string | Severity to apply to the alert event
 **on_poll_alert_status** |  optional  | string | Comma separated list of alert statuses to poll (New, Pending, Dismissed, Resolved are now supported)
+**on_poll_alert_full_alert** |  optional  | string | Scope of artifact ingestion
 **ph1** |  optional  | ph | 
 **max_count** |  optional  | numeric | Max events to ingest for scheduled polling
 **ph2** |  optional  | ph | 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Product Name: Recorded Future App for Phantom
 Product Version Supported (regex): ".\*"  
 Minimum Product Version: 6.3.0  
 
-Enhance your security posture with Recorded Future for Splunk SOAR.
-Key Capabilities:
-•Swift Threat Assessments: Access Recorded Future's extensive IOC data for swift and accurate assessments
+This app implements investigative actions to perform lookups for quick reputation information, contextual threat intelligence and external threat alerts
 
 [comment]: # " File: README.md"
 [comment]: # ""
@@ -33,10 +31,12 @@ Key Capabilities:
 [comment]: # "either express or implied. See the License for the specific language governing permissions"
 [comment]: # "and limitations under the License."
 [comment]: # ""
-Recorded Future App for Phantom allows clients to work smarter, respond faster, and strengthen their
-defenses through automation and orchestration. The Recorded Future App provides a number of actions
-that enable the creation of Playbooks to do automated enrichment, correlation, threat hunting, and
-alert handling.
+Recorded Future App for Splunk SOAR allows clients to work smarter, respond faster, and strengthen their 
+defenses through automation and orchestration. The Recorded Future App provides a number of actions that enable 
+the creation of Playbooks to do automated enrichment, correlation, threat hunting, and alert handling.
+
+Access playbook templates created by Recorded Future automation experts to embed intelligence in your new 
+and existing security workflows: https://support.recordedfuture.com/hc/en-us/articles/12294483605523-Splunk-SOAR-Template-Playbooks-Library
 
 # Ingest alerts into events
 

--- a/recordedfuture.json
+++ b/recordedfuture.json
@@ -41,12 +41,7 @@
             "required": true,
             "order": 2
         },
-        "recordedfuture_verify_ssl": {
-            "description": "Verify SSL certificates",
-            "data_type": "boolean",
-            "default": true,
-            "order": 4
-        },
+
         "on_poll_alert_ruleids": {
             "data_type": "string",
             "order": 1,
@@ -63,65 +58,85 @@
                 "Low"
             ]
         },
+        "on_poll_alert_full_alert": {
+            "description": "Scope of artifact ingestion",
+            "data_type": "string",
+            "default":  "All entities",
+            "order": 5,
+            "value_list": [
+                "All entities",
+                "Only entities that triggered alert"
+            ]
+        },
         "on_poll_alert_status": {
             "data_type": "string",
-            "order": 5,
+            "order": 6,
             "description": "Comma separated list of alert statuses to poll (New, Pending, Dismissed, Resolved are now supported)"
         },
-        "ph1": {
+        "recordedfuture_verify_ssl": {
+            "description": "Verify SSL certificates",
+            "data_type": "boolean",
+            "default": true,
+            "order": 4
+        },
+        "ph0": {
             "data_type": "ph",
             "order": 6
         },
+        "ph1": {
+            "data_type": "ph",
+            "order": 7
+        },
         "max_count": {
             "data_type": "numeric",
-            "order": 7,
+            "order": 8,
             "description": "Max events to ingest for scheduled polling",
             "default": 100
         },
         "ph2": {
             "data_type": "ph",
-            "order": 8
+            "order": 9
         },
         "first_max_count": {
             "data_type": "numeric",
-            "order": 9,
+            "order": 10,
             "description": "Max events to ingest for scheduled polling first time",
             "default": 100
         },
         "ph3": {
             "data_type": "ph",
-            "order": 10
+            "order": 11
         },
         "on_poll_playbook_alert_priority": {
             "data_type": "string",
-            "order": 11,
+            "order": 12,
             "description": "Comma separated On Poll Playbook Alerts priority threshold (High,Moderate,Informational)"
         },
         "ph4": {
             "data_type": "ph",
-            "order": 12
+            "order": 13
         },
         "on_poll_playbook_alert_type": {
             "data_type": "string",
-            "order": 13,
+            "order": 14,
             "description": "Comma-separated list of Playbook alert types. (domain_abuse, cyber_vulnerability, code_repo_leakage are now supported)"
         },
         "ph6": {
             "data_type": "ph",
-            "order": 14
+            "order": 15
         },
         "on_poll_playbook_alert_status": {
             "data_type": "string",
-            "order": 15,
+            "order": 16,
             "description": "Comma-separated list of Playbook alert statuses. (New, InProgress, Dismissed, Resolved are now supported)"
         },
         "ph7": {
             "data_type": "ph",
-            "order": 16
+            "order": 17
         },
         "on_poll_playbook_alert_start_time": {
             "data_type": "string",
-            "order": 17,
+            "order": 18,
             "description": "Poll playbook alerts created after (date in ISO format: 2022-12-01T11:00:00+00)"
         }
     },

--- a/recordedfuture_connector.py
+++ b/recordedfuture_connector.py
@@ -959,6 +959,7 @@ class RecordedfutureConnector(BaseConnector):
             "rules": rule_list,
             "severity": config.get("on_poll_alert_severity"),
             "limit": param.get("max_count", 100),
+            "limited_entity_scope": config.get("on_poll_alert_full_alert") != "All entities",
         }
         params["status"] = [el.strip() for el in config.get("on_poll_alert_status", "").split(",") if el.strip()]
 


### PR DESCRIPTION
Adds a new dropdown parameter that controls  if we are to ingest the full scope of entities associated with an alert, or a subset as denoted by "triggered_by" section of alert response. 