### PR TITLE
RFPD-74861: Context in threat assessment parameter is ambigous for splunk soar

### DIFF
--- a/recordedfuture.json
+++ b/recordedfuture.json
@@ -6443,13 +6443,6 @@
                 "entity_type": {
                     "description": "Entity Type",
                     "data_type": "string",
-                    "value_list": [
-                        "ip",
-                        "domain",
-                        "url",
-                        "hash",
-                        "vulnerability"
-                    ],
                     "order": 1
                 },
                 "limit": {


### PR DESCRIPTION
[RFPD-74861](https://recordedfuture.atlassian.net/browse/RFPD-74861) Update threat_context to use dropdown in threat assessment action

