### PR TITLE
RFPD-22681: Splunk SOAR - Combine List Search and List Details into one action

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 [create list](#action-create-list) - Create new list <br>
 [list add entity](#action-list-add-entity) - Add new entity to list <br>
 [list remove entity](#action-list-remove-entity) - Remove entity from list <br>
-[list details](#action-list-details) - Get list details <br>
+[list details](#action-list-details) - Get list details. DEPRECATED: use 'list search' with 'list_id' parameter instead. This action will be removed in a future release <br>
 [list status](#action-list-status) - Get list status info <br>
 [list entities](#action-list-entities) - Get list entities <br>
 [ip reputation](#action-ip-reputation) - Get a quick indicator of the risk associated with an IP address <br>
@@ -954,6 +954,7 @@ Read only: **True**
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **list_name** | optional | List Name | string | |
+**list_id** | optional | List ID. If provided, returns details for a specific list. Cannot be combined with list_name or entity_types; limit is ignored when list_id is provided. Note: you can obtain List ID from a previous 'list search' by name. | string | |
 **entity_types** | optional | Entity Types | string | |
 **limit** | optional | Limit number of records in response | numeric | |
 
@@ -974,6 +975,7 @@ action_result.summary | string | | |
 action_result.message | string | `recordedfuture result message` | |
 summary.total_objects | numeric | `recordedfuture total objects` | 1 |
 summary.total_objects_successful | numeric | `recordedfuture total objects successful` | 1 |
+action_result.parameter.list_id | string | | |
 
 ## action: 'create list'
 
@@ -1070,7 +1072,7 @@ summary.total_objects_successful | numeric | `recordedfuture total objects succe
 
 ## action: 'list details'
 
-Get list details
+Get list details. DEPRECATED: use 'list search' with 'list_id' parameter instead. This action will be removed in a future release
 
 Type: **investigate** <br>
 Read only: **True**

--- a/recordedfuture.json
+++ b/recordedfuture.json
@@ -4543,6 +4543,11 @@
                     "data_type": "string",
                     "order": 0
                 },
+                "list_id": {
+                    "description": "List ID. If provided, returns details for a specific list. Cannot be combined with list_name or entity_types; limit is ignored when list_id is provided. Note: you can obtain List ID from a previous 'list search' by name.",
+                    "data_type": "string",
+                    "order": 1
+                },
                 "entity_types": {
                     "description": "Entity Types",
                     "data_type": "string",
@@ -4568,13 +4573,13 @@
                         "target",
                         "method"
                     ],
-                    "order": 1
+                    "order": 2
                 },
                 "limit": {
                     "description": "Limit number of records in response",
                     "data_type": "numeric",
                     "default": 25,
-                    "order": 2
+                    "order": 3
                 }
             },
             "output": [
@@ -4651,6 +4656,10 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.list_id",
+                    "data_type": "string"
                 }
             ],
             "render": {
@@ -5004,7 +5013,7 @@
         {
             "action": "list details",
             "identifier": "list_details",
-            "description": "Get list details",
+            "description": "Get list details. DEPRECATED: use 'list search' with 'list_id' parameter instead. This action will be removed in a future release",
             "type": "investigate",
             "read_only": true,
             "parameters": {

--- a/recordedfuture_connector.py
+++ b/recordedfuture_connector.py
@@ -465,7 +465,7 @@ class RecordedfutureConnector(BaseConnector):
         )
 
         # Do not fail on 404. Give a message to user with success status.
-        if phantom.is_fail(my_ret_val) and response.status_code == 404:
+        if phantom.is_fail(my_ret_val) and response is not None and response.status_code == 404:
             action_result.set_status(
                 phantom.APP_SUCCESS,
                 status_message="Recorded Future does not have any information on this indicator.",
@@ -546,6 +546,11 @@ class RecordedfutureConnector(BaseConnector):
         if action == "search":
             return self._handle_list_search(param)
         if action == "details":
+            self.save_progress(
+                "DEPRECATION WARNING: 'list details' action is deprecated and will be "
+                "removed in a future release. Please use 'list search' with 'list_id' "
+                "parameter instead."
+            )
             return self._handle_list_details(param, info_type="info")
         if action == "entities":
             return self._handle_list_details(param, info_type="entities")
@@ -571,27 +576,50 @@ class RecordedfutureConnector(BaseConnector):
         """Find lists"""
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(param))
-        params = {"limit": param.get("limit", 25)}
-        entity_types = param.get("entity_types", "")
+
+        list_id = param.get("list_id")
         list_name = param.get("list_name", "")
-        if entity_types:
-            params["type"] = UnicodeDammit(escape(entity_types)).unicode_markup
-        if list_name:
-            params["name"] = UnicodeDammit(escape(list_name)).unicode_markup
+        entity_types = param.get("entity_types", "")
 
-        my_ret_val, response = self._make_rest_call("/list/search", action_result, json=params, method="post")
+        if list_id and (list_name or entity_types):
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                "Invalid parameters: 'list_id' cannot be combined with 'list_name' or 'entity_types'. "
+                "Provide either 'list_id' alone or use 'list_name'/'entity_types' for search.",
+            )
 
-        self.debug_print(
-            "_handle_list_search",
-            {
-                "endpoint": "/list/search",
-                "action_result": action_result,
-                "param": param,
-                "params": params,
-                "my_ret_val": my_ret_val,
-                "response": response,
-            },
-        )
+        if list_id:
+            list_id = UnicodeDammit(list_id).unicode_markup
+            my_ret_val, response = self._make_rest_call(f"/list/{list_id}/info", action_result, method="get")
+            self.debug_print(
+                "_handle_list_search",
+                {
+                    "endpoint": f"/list/{list_id}/info",
+                    "action_result": action_result,
+                    "param": param,
+                    "my_ret_val": my_ret_val,
+                    "response": response,
+                },
+            )
+        else:
+            params = {"limit": param.get("limit", 25)}
+            if entity_types:
+                params["type"] = UnicodeDammit(escape(entity_types)).unicode_markup
+            if list_name:
+                params["name"] = UnicodeDammit(escape(list_name)).unicode_markup
+
+            my_ret_val, response = self._make_rest_call("/list/search", action_result, json=params, method="post")
+            self.debug_print(
+                "_handle_list_search",
+                {
+                    "endpoint": "/list/search",
+                    "action_result": action_result,
+                    "param": param,
+                    "params": params,
+                    "my_ret_val": my_ret_val,
+                    "response": response,
+                },
+            )
 
         return self._get_list_action_result(
             action_result=action_result,

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* List Search: Added `list_id` parameter to allow searching by list ID directly; deprecated the separate `list details` action.

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+def test_alert_search_no_results(rf_connector, requests_mock):
+    """When no alerts match, action should succeed with a message."""
+    in_json: InputJSON = {
+        "action": "alert search",
+        "identifier": "alert_search",
+        "config": {},
+        "parameters": [{"rule_id": "rule123", "timeframe": "-7d"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/alert/rule/rule123",
+        json={"counts": {"total": 0, "returned": 0}, "data": {"results": []}},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["total_number_of_alerts"] == 0
+
+
+def test_alert_search_with_results(rf_connector, requests_mock):
+    """When alerts exist, should also look up each alert by ID."""
+    in_json: InputJSON = {
+        "action": "alert search",
+        "identifier": "alert_search",
+        "config": {},
+        "parameters": [{"rule_id": "rule123", "timeframe": "-7d"}],
+        "environment_variables": {},
+    }
+
+    rule_response = {
+        "counts": {"total": 1, "returned": 1},
+        "data": {"results": [{"id": "alert001", "rule": {"id": "rule123", "name": "Test Rule"}}]},
+    }
+    alert_detail = {"id": "alert001", "title": "Alert One", "triggered": "2025-01-01T00:00:00Z"}
+
+    requests_mock.get(f"{BASE_URL}/alert/rule/rule123", json=rule_response, headers=JSON_HEADERS)
+    requests_mock.get(f"{BASE_URL}/alert/lookup/alert001", json=alert_detail, headers=JSON_HEADERS)
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["rule_name"] == "Test Rule"
+
+
+def test_alert_search_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "alert search",
+        "identifier": "alert_search",
+        "config": {},
+        "parameters": [{"rule_id": "rule123", "timeframe": "-7d"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(f"{BASE_URL}/alert/rule/rule123", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_alert_lookup_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "alert lookup",
+        "identifier": "alert_lookup",
+        "config": {},
+        "parameters": [{"alert_id": "alert001"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/alert/lookup/alert001",
+        json={"id": "alert001", "title": "Phishing Campaign", "triggered": "2025-01-15T12:00:00Z"},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    summary = result.get_summary()
+    assert summary["alert_title"] == "Phishing Campaign"
+    assert summary["triggered"] == "2025-01-15T12:00:00Z"
+
+
+def test_alert_lookup_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "alert lookup",
+        "identifier": "alert_lookup",
+        "config": {},
+        "parameters": [{"alert_id": "nonexistent"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(f"{BASE_URL}/alert/lookup/nonexistent", status_code=404, json={"message": "Not Found"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_alert_update_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "alert update",
+        "identifier": "alert_update",
+        "config": {},
+        "parameters": [{"alert_id": "alert001", "alert_status": "Pending", "alert_note": "Investigating"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/alert/update",
+        json={"success": [{"id": "alert001", "status": "Pending"}]},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == [{"id": "alert001", "status": "Pending", "note": "Investigating"}],
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["update"] == "Successful"
+
+
+def test_alert_update_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "alert update",
+        "identifier": "alert_update",
+        "config": {},
+        "parameters": [{"alert_id": "alert001", "alert_status": "Pending", "alert_note": ""}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/alert/update", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_alert_rule_search_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "alert rule search",
+        "identifier": "alert_rule_search",
+        "config": {},
+        "parameters": [{"rule_search": "phishing"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/config/alert/rules",
+        json={
+            "counts": {"returned": 2, "total": 2},
+            "data": {"results": [{"id": "r1", "title": "Phishing Rule"}, {"id": "r2", "title": "Phishing Advanced"}]},
+        },
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    summary = result.get_summary()
+    assert summary["rules_returned"] == 2
+    assert "r1" in summary["rule_id_list"]
+    assert "r2" in summary["rule_id_list"]
+
+
+def test_alert_rule_search_no_query(rf_connector, requests_mock):
+    """When no rule_search param, should still call the endpoint with just limit."""
+    in_json: InputJSON = {
+        "action": "alert rule search",
+        "identifier": "alert_rule_search",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/config/alert/rules",
+        json={"counts": {"returned": 0, "total": 0}, "data": {"results": []}},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["rules_returned"] == 0

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+MOCKED_INTELLIGENCE_RESPONSE = {
+    "data": {
+        "entity": {"id": "ip:1.2.3.4", "name": "1.2.3.4"},
+        "risk": {"criticalityLabel": "High", "riskSummary": "3 of 10 rules triggered"},
+        "timestamps": {"lastSeen": "2025-01-01T00:00:00Z"},
+    }
+}
+
+
+def _make_intelligence_in_json(action_name, identifier, param_key, param_value):
+    return {
+        "action": action_name,
+        "identifier": identifier,
+        "config": {},
+        "parameters": [{param_key: param_value}],
+        "environment_variables": {},
+    }
+
+
+def test_ip_intelligence_success(rf_connector, requests_mock):
+    in_json: InputJSON = _make_intelligence_in_json("ip intelligence", "ip_intelligence", "ip", "1.2.3.4")
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/intelligence",
+        json=MOCKED_INTELLIGENCE_RESPONSE,
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"entity_type": "ip", "ioc": "1.2.3.4"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    summary = result.get_summary()
+    assert summary["criticalityLabel"] == "High"
+    assert summary["riskSummary"] == "3 of 10 rules triggered"
+    assert summary["lastSeen"] == "2025-01-01T00:00:00Z"
+
+
+def test_domain_intelligence_success(rf_connector, requests_mock):
+    in_json: InputJSON = _make_intelligence_in_json("domain intelligence", "domain_intelligence", "domain", "example.com")
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/intelligence",
+        json={"data": {"entity": {"id": "domain:example.com"}, "risk": {}}},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"entity_type": "domain", "ioc": "example.com"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_file_intelligence_success(rf_connector, requests_mock):
+    """File intelligence uses 'hash' as the parameter key."""
+    in_json: InputJSON = _make_intelligence_in_json("file intelligence", "file_intelligence", "hash", "abc123hash")
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/intelligence",
+        json={"data": {"entity": {"id": "hash:abc123hash"}, "risk": {}}},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"entity_type": "file", "ioc": "abc123hash"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_url_intelligence_success(rf_connector, requests_mock):
+    in_json: InputJSON = _make_intelligence_in_json("url intelligence", "url_intelligence", "url", "http://evil.com")
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/intelligence",
+        json={"data": {"entity": {"id": "url:http://evil.com"}, "risk": {}}},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"entity_type": "url", "ioc": "http://evil.com"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_vulnerability_intelligence_success(rf_connector, requests_mock):
+    in_json: InputJSON = _make_intelligence_in_json(
+        "vulnerability intelligence", "vulnerability_intelligence", "vulnerability", "CVE-2021-44228"
+    )
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/intelligence",
+        json={"data": {"entity": {"id": "vulnerability:CVE-2021-44228"}, "risk": {}}},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"entity_type": "vulnerability", "ioc": "CVE-2021-44228"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_ip_intelligence_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = _make_intelligence_in_json("ip intelligence", "ip_intelligence", "ip", "1.2.3.4")
+
+    requests_mock.post(f"{BASE_URL}/lookup/intelligence", status_code=500, json={"message": "Internal Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False

--- a/tests/test_list_actions.py
+++ b/tests/test_list_actions.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+def test_list_create_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list create",
+        "identifier": "list_create",
+        "config": {},
+        "parameters": [{"list_name": "My New List", "entity_types": "ip"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/list/create",
+        json={"id": "new123", "name": "My New List", "type": "ip"},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"name": "My New List", "type": "ip"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_create_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list create",
+        "identifier": "list_create",
+        "config": {},
+        "parameters": [{"list_name": "Bad List", "entity_types": "ip"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/list/create", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_list_entities_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list entities",
+        "identifier": "list_entities",
+        "config": {},
+        "parameters": [{"list_id": "abc123"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/list/abc123/entities",
+        json={"entities": [{"id": "e1", "name": "1.2.3.4"}]},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_status_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list status",
+        "identifier": "list_status",
+        "config": {},
+        "parameters": [{"list_id": "abc123"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/list/abc123/status",
+        json={"status": "active", "count": 10},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_add_entity_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list add entity",
+        "identifier": "list_add-entity",
+        "config": {},
+        "parameters": [{"list_id": "abc123", "entity_id": "ip:1.2.3.4", "entity_name": "1.2.3.4", "entity_type": "ip"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/list/abc123/entity/add",
+        json={"status": "added"},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_remove_entity_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list remove entity",
+        "identifier": "list_remove-entity",
+        "config": {},
+        "parameters": [{"list_id": "abc123", "entity_id": "ip:1.2.3.4"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/list/abc123/entity/remove",
+        json={"status": "removed"},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_add_entity_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list add entity",
+        "identifier": "list_add-entity",
+        "config": {},
+        "parameters": [{"list_id": "abc123", "entity_id": "ip:1.2.3.4"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/list/abc123/entity/add", status_code=403, json={"message": "Forbidden"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False

--- a/tests/test_list_search.py
+++ b/tests/test_list_search.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+MOCKED_LIST_INFO = {
+    "id": "abc123",
+    "name": "My List",
+    "type": "ip",
+}
+
+MOCKED_LIST_SEARCH_RESPONSE = [
+    {"id": "abc123", "name": "My List", "type": "ip"},
+    {"id": "def456", "name": "Another List", "type": "domain"},
+]
+
+
+def test_list_search_by_list_id(rf_connector, requests_mock):
+    """When list_id is provided, should GET /list/{list_id}/info."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_id": "abc123"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/list/abc123/info",
+        json=MOCKED_LIST_INFO,
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert requests_mock.last_request.method == "GET"
+
+
+def test_list_search_by_name(rf_connector, requests_mock):
+    """When list_name is provided (no list_id), should POST /list/search with name filter."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_name": "My List", "limit": 10}],
+        "environment_variables": {},
+    }
+
+    expected_payload = {"limit": 10, "name": "My List"}
+
+    requests_mock.post(
+        f"{BASE_URL}/list/search",
+        json=MOCKED_LIST_SEARCH_RESPONSE,
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == expected_payload,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_search_by_entity_types(rf_connector, requests_mock):
+    """When entity_types is provided (no list_id), should POST /list/search with type filter."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"entity_types": "ip", "limit": 5}],
+        "environment_variables": {},
+    }
+
+    expected_payload = {"limit": 5, "type": "ip"}
+
+    requests_mock.post(
+        f"{BASE_URL}/list/search",
+        json=MOCKED_LIST_SEARCH_RESPONSE,
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == expected_payload,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_search_no_filters_uses_default_limit(rf_connector, requests_mock):
+    """When no filters provided, should POST /list/search with default limit of 25."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    expected_payload = {"limit": 25}
+
+    requests_mock.post(
+        f"{BASE_URL}/list/search",
+        json=MOCKED_LIST_SEARCH_RESPONSE,
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == expected_payload,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_list_search_by_list_id_api_error(rf_connector, requests_mock):
+    """When list_id is provided but API returns error, action should fail."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_id": "nonexistent"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/list/nonexistent/info",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_list_search_list_id_with_list_name_returns_error(rf_connector, requests_mock):
+    """When both list_id and list_name are provided, action should fail with a validation error."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_id": "abc123", "list_name": "My List"}],
+        "environment_variables": {},
+    }
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+    assert requests_mock.call_count == 0
+
+
+def test_list_search_list_id_with_entity_types_returns_error(rf_connector, requests_mock):
+    """When both list_id and entity_types are provided, action should fail with a validation error."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_id": "abc123", "entity_types": "ip"}],
+        "environment_variables": {},
+    }
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+    assert requests_mock.call_count == 0
+
+
+def test_list_details_deprecation_warning(rf_connector, requests_mock):
+    """list details action should still work but emit a visible deprecation warning."""
+    in_json: InputJSON = {
+        "action": "list details",
+        "identifier": "list_details",
+        "config": {},
+        "parameters": [{"list_id": "abc123"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/list/abc123/info",
+        json=MOCKED_LIST_INFO,
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    rf_connector.save_progress.assert_any_call(
+        "DEPRECATION WARNING: 'list details' action is deprecated and will be "
+        "removed in a future release. Please use 'list search' with 'list_id' "
+        "parameter instead."
+    )

--- a/tests/test_misc_actions.py
+++ b/tests/test_misc_actions.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+def test_test_connectivity_success(rf_connector, requests_mock):
+    requests_mock.get(f"{BASE_URL}/helo", json={}, headers=JSON_HEADERS)
+    requests_mock.get(f"{BASE_URL}/config/info", json={}, headers=JSON_HEADERS)
+
+    in_json: InputJSON = {
+        "action": "test connectivity",
+        "identifier": "test_connectivity",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    rf_connector.save_progress.assert_any_call("Connectivity and credentials test passed. You may now close this window")
+
+
+def test_test_connectivity_failure(rf_connector, requests_mock):
+    requests_mock.get(f"{BASE_URL}/helo", status_code=401, json={"message": "Unauthorized"})
+
+    in_json: InputJSON = {
+        "action": "test connectivity",
+        "identifier": "test_connectivity",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+    rf_connector.save_progress.assert_any_call("Connectivity test failed. API endpoint not reachable")
+
+
+def test_list_contexts_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list contexts",
+        "identifier": "list_contexts",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/config/triage/contexts",
+        json={"malware": {"name": "Malware", "datagroup": "malware"}, "phishing": {"name": "Phishing", "datagroup": "phishing"}},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert "malware" in result.get_summary()["contexts_available_for_threat_assessment"]
+
+
+def test_list_contexts_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "list contexts",
+        "identifier": "list_contexts",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(f"{BASE_URL}/config/triage/contexts", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_threat_assessment_malicious(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "threat assessment",
+        "identifier": "threat_assessment",
+        "config": {},
+        "parameters": [{"threat_context": "malware", "ip": "1.2.3.4"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/triage/malware?&format=phantom",
+        json={"verdict": True, "triage_riskscore": 85, "entities": [{"id": "ip:1.2.3.4"}]},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["assessment"] == "Suspected to be malicious"
+    assert result.get_summary()["riskscore"] == 85
+
+
+def test_threat_assessment_not_malicious(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "threat assessment",
+        "identifier": "threat_assessment",
+        "config": {},
+        "parameters": [{"threat_context": "malware", "ip": "8.8.8.8"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/triage/malware?&format=phantom",
+        json={"verdict": False, "triage_riskscore": 5, "entities": [{"id": "ip:8.8.8.8"}]},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["assessment"] == "Not found to be malicious"
+
+
+def test_entity_search_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "entity search",
+        "identifier": "entity_search",
+        "config": {},
+        "parameters": [{"name": "Lazarus", "entity_type": "ThreatActor", "limit": 5}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/entity/search",
+        json={"data": [{"id": "ta:Lazarus", "name": "Lazarus Group"}]},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"name": "Lazarus", "type": "ThreatActor", "limit": 5},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_entity_search_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "entity search",
+        "identifier": "entity_search",
+        "config": {},
+        "parameters": [{"name": "Lazarus"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/entity/search", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_links_search_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "links search",
+        "identifier": "links_search",
+        "config": {},
+        "parameters": [{"entity_id": "ip:1.2.3.4", "timeframe": "-30d"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/links/search",
+        json={"links": [{"source": "ip:1.2.3.4", "target": "malware:abc"}]},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json().get("entity_id") == "ip:1.2.3.4",
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_links_search_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "links search",
+        "identifier": "links_search",
+        "config": {},
+        "parameters": [{"entity_id": "ip:1.2.3.4"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/links/search", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_threat_map_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "threat map",
+        "identifier": "threat_map",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/threat/map",
+        json={"actors": [{"id": "ta:Lazarus", "name": "Lazarus Group"}]},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_threat_actor_intelligence_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "threat actor intelligence",
+        "identifier": "threat_actor_intelligence",
+        "config": {},
+        "parameters": [{"threat_actor": "Lazarus", "links": True}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/threat/map/actors",
+        json={"actor": {"id": "ta:Lazarus", "name": "Lazarus Group"}, "links": []},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"threat_actor": "Lazarus", "links": True},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_collective_insights_submit_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "collective insights submit",
+        "identifier": "collective_insights_submit",
+        "config": {},
+        "parameters": [{"entity_name": "1.2.3.4", "entity_type": "ip", "event_type": "c2"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/collective-insights/detections",
+        json={"status": "accepted"},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_fetch_analyst_notes_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "fetch analyst notes",
+        "identifier": "fetch_analyst_notes",
+        "config": {},
+        "parameters": [{"topic": "malware", "published": "-7d", "limit": 5}],
+        "environment_variables": {},
+    }
+
+    mocked_notes = [
+        {"id": "note1", "title": "Malware Analysis", "published": "2025-01-10"},
+        {"id": "note2", "title": "Campaign Report", "published": "2025-01-09"},
+    ]
+
+    requests_mock.post(
+        f"{BASE_URL}/analyst_note/fetch_notes",
+        json=mocked_notes,
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json().get("topic") == "malware" and req.json().get("limit") == 5,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary()["total_notes"] == 2
+
+
+def test_fetch_analyst_notes_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "fetch analyst notes",
+        "identifier": "fetch_analyst_notes",
+        "config": {},
+        "parameters": [{"topic": "malware"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/analyst_note/fetch_notes", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False

--- a/tests/test_playbook_alerts.py
+++ b/tests/test_playbook_alerts.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+def test_playbook_alerts_search_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "playbook alerts search",
+        "identifier": "playbook_alerts_search",
+        "config": {},
+        "parameters": [{"category": "domain_abuse", "status": "New", "limit": 10}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/playbook_alert/search",
+        json={"alerts": [{"id": "pa001", "category": "domain_abuse"}]},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json().get("categories") == ["domain_abuse"] and req.json().get("statuses") == ["New"],
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_playbook_alerts_search_no_filters(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "playbook alerts search",
+        "identifier": "playbook_alerts_search",
+        "config": {},
+        "parameters": [{}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/playbook_alert/search",
+        json={"alerts": []},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_playbook_alerts_search_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "playbook alerts search",
+        "identifier": "playbook_alerts_search",
+        "config": {},
+        "parameters": [{"category": "domain_abuse"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/playbook_alert/search", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_playbook_alert_details_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "playbook alert details",
+        "identifier": "playbook_alert_details",
+        "config": {},
+        "parameters": [{"alert_id": "pa001"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/playbook_alert/pa001",
+        json={"id": "pa001", "category": "domain_abuse", "status": "New"},
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_playbook_alert_details_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "playbook alert details",
+        "identifier": "playbook_alert_details",
+        "config": {},
+        "parameters": [{"alert_id": "nonexistent"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(f"{BASE_URL}/playbook_alert/nonexistent", status_code=404, json={"message": "Not Found"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False
+
+
+def test_update_playbook_alert_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "update playbook alert",
+        "identifier": "update_playbook_alert",
+        "config": {},
+        "parameters": [{"alert_id": "pa001", "status": "In Progress", "priority": "High", "log_message": "Under investigation"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.put(
+        f"{BASE_URL}/playbook_alert/pa001",
+        json={"id": "pa001", "status": "InProgress"},
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json().get("status") == "InProgress",
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_update_playbook_alert_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "update playbook alert",
+        "identifier": "update_playbook_alert",
+        "config": {},
+        "parameters": [{"alert_id": "pa001", "status": "Resolved"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.put(f"{BASE_URL}/playbook_alert/pa001", status_code=403, json={"message": "Forbidden"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False

--- a/tests/test_reputation.py
+++ b/tests/test_reputation.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2025-2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pytest_splunk_soar_connectors.models import InputJSON
+
+
+BASE_URL = "http://localhost:8089/phantom"
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+# Reputation response is a list; handler pops the first element
+MOCKED_REPUTATION_RESPONSE = [{"id": "ip:1.2.3.4", "name": "1.2.3.4", "riskscore": 75, "rulecount": 3, "maxrules": 10}]
+
+
+def test_ip_reputation_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "ip reputation",
+        "identifier": "ip_reputation",
+        "config": {},
+        "parameters": [{"ip": "1.2.3.4"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/reputation",
+        json=MOCKED_REPUTATION_RESPONSE,
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"ip": "1.2.3.4"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    summary = result.get_summary()
+    assert summary["risk score"] == 75
+    assert summary["risk summary"] == "3 rules triggered of 10"
+
+
+def test_domain_reputation_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "domain reputation",
+        "identifier": "domain_reputation",
+        "config": {},
+        "parameters": [{"domain": "evil.com"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/reputation",
+        json=[{"id": "domain:evil.com", "name": "evil.com", "riskscore": 90, "rulecount": 5, "maxrules": 10}],
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"domain": "evil.com"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_url_reputation_success(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "url reputation",
+        "identifier": "url_reputation",
+        "config": {},
+        "parameters": [{"url": "http://evil.com/malware"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/reputation",
+        json=[{"id": "url:http://evil.com/malware", "name": "http://evil.com/malware", "riskscore": 60, "rulecount": 2, "maxrules": 10}],
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"url": "http://evil.com/malware"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_file_reputation_success(rf_connector, requests_mock):
+    """File reputation uses 'hash' as both the param key and category."""
+    in_json: InputJSON = {
+        "action": "file reputation",
+        "identifier": "file_reputation",
+        "config": {},
+        "parameters": [{"hash": "test-file-hash-xyz"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/reputation",
+        json=[{"id": "hash:test-file-hash-xyz", "name": "test-file-hash-xyz", "riskscore": 50, "rulecount": 1, "maxrules": 10}],
+        headers=JSON_HEADERS,
+        additional_matcher=lambda req: req.json() == {"hash": "test-file-hash-xyz"},
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+
+
+def test_ip_reputation_no_data(rf_connector, requests_mock):
+    """When entity has no id, summary shows 'No information available'."""
+    in_json: InputJSON = {
+        "action": "ip reputation",
+        "identifier": "ip_reputation",
+        "config": {},
+        "parameters": [{"ip": "10.0.0.1"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/lookup/reputation",
+        json=[{}],  # empty entity — no 'id' key
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is True
+    assert result.get_summary().get("riskscore") == "No information available."
+
+
+def test_ip_reputation_api_error(rf_connector, requests_mock):
+    in_json: InputJSON = {
+        "action": "ip reputation",
+        "identifier": "ip_reputation",
+        "config": {},
+        "parameters": [{"ip": "1.2.3.4"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(f"{BASE_URL}/lookup/reputation", status_code=500, json={"message": "Server Error"})
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+
+    result = rf_connector.get_action_results()[0]
+    assert result.get_status() is False


### PR DESCRIPTION
## Details
Consolidates `list search` and `list details` actions by adding `list_id` as an optional parameter to `list search`.
                                                                                                                                                         
  - Added `list_id` as an optional parameter to the `list search` action, allowing users to look up a specific list by ID without needing a separate action (when provided, returns details for a specific list via `/list/{list_id}/info`).
  - Deprecated the list details action - it now emits a visible warning (save_progress) and its description is updated to direct users to list search with `list_id` instead.
  - Added unit test coverage for all connector actions.                                                                                                                                

## Summary                                                                                                                                                                                                                                                                        
Two actions `list search` (filter by name/type) and list details (lookup by ID) will returned identical output but served different input patterns. Rather than merging them (which would blur the architectural separation of filter-based vs. ID-based lookups), `list_id` was added as an optional parameter to list search. This gives users flexibility while keeping both actions clean and focused. `list details` is preserved for backwards compatibility but marked as deprecated for future removal.
