### PR TITLE
RFPD-107086: fix empty list search widget when searching by list_id

### DIFF
--- a/recordedfuture_view.py
+++ b/recordedfuture_view.py
@@ -332,6 +332,12 @@ def list_search_results(provides, all_app_runs, context):
             result_data = result.get_data()
             if result_data:
                 result_data = result_data[0]
+                # When searching by list_id the API returns a single list object
+                # (GET /list/{id}/info); a name/type search returns an array
+                # (POST /list/search). Normalize the single object into a list so
+                # the template can iterate over it uniformly.
+                if isinstance(result_data, dict):
+                    result_data = [result_data]
             results.append({"param": result.get_param(), "data": result_data})
 
     return "views/list_search_results.html"

--- a/tests/test_list_search.py
+++ b/tests/test_list_search.py
@@ -15,6 +15,8 @@ import json
 
 from pytest_splunk_soar_connectors.models import InputJSON
 
+from recordedfuture_view import list_search_results
+
 
 BASE_URL = "http://localhost:8089/phantom"
 JSON_HEADERS = {"Content-Type": "application/json"}
@@ -211,3 +213,62 @@ def test_list_details_deprecation_warning(rf_connector, requests_mock):
         "removed in a future release. Please use 'list search' with 'list_id' "
         "parameter instead."
     )
+
+
+def test_list_search_view_renders_list_id_result(rf_connector, requests_mock):
+    """RFPD-107086: searching by list_id returns a single object (GET /list/{id}/info),
+    while the widget template iterates result.data. The view must normalize the single
+    object into a list so the widget renders it instead of showing an empty table."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_id": "abc123"}],
+        "environment_variables": {},
+    }
+
+    requests_mock.get(
+        f"{BASE_URL}/list/abc123/info",
+        json=MOCKED_LIST_INFO,
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+    results = rf_connector.get_action_results()
+
+    context = {}
+    list_search_results(None, [(None, results)], context)
+
+    rendered = context["results"][0]["data"]
+    # Must be an iterable of list objects (not the raw dict) so the template's
+    # `{% for el in result.data %}` yields data rows instead of dict keys.
+    assert rendered == [MOCKED_LIST_INFO]
+    assert rendered[0]["name"] == "My List"
+
+
+def test_list_search_view_renders_name_search_result(rf_connector, requests_mock):
+    """A name/type search returns an array (POST /list/search); the view must leave
+    that array untouched so every matched list renders."""
+    in_json: InputJSON = {
+        "action": "list search",
+        "identifier": "list_search",
+        "config": {},
+        "parameters": [{"list_name": "My List", "limit": 10}],
+        "environment_variables": {},
+    }
+
+    requests_mock.post(
+        f"{BASE_URL}/list/search",
+        json=MOCKED_LIST_SEARCH_RESPONSE,
+        headers=JSON_HEADERS,
+    )
+
+    rf_connector._handle_action(json.dumps(in_json), None)
+    results = rf_connector.get_action_results()
+
+    context = {}
+    list_search_results(None, [(None, results)], context)
+
+    rendered = context["results"][0]["data"]
+    assert rendered == MOCKED_LIST_SEARCH_RESPONSE
+    assert len(rendered) == 2


### PR DESCRIPTION
## Summary

Fixes [RFPD-107086](https://recordedfuture.atlassian.net/browse/RFPD-107086) — *Splunk SOAR: List is not shown on widget*.

When `list search` is run with a `list_id`, the widget shows an empty table even though the JSON data is present.

## Root cause

The `list search` action (added in RFPD-22681) hits two endpoints with different response shapes:

| Path | Endpoint | Shape |
|------|----------|-------|
| `list_name` / `entity_types` / none | `POST /list/search` | **array** of lists |
| `list_id` | `GET /list/{id}/info` | **single** object |

Both flow through the `list_search_results` view, whose template iterates `{% for el in result.data %}`. With `list_id`, `result.data` is a single dict, so Django iterates its **keys** and `el.name`/`el.id` resolve empty → empty widget.

## Fix

Normalize the single-object response into a list in `list_search_results` so the template renders it uniformly.

<img width="1728" height="845" alt="Screenshot 2026-07-16 at 18 19 31" src="https://github.com/user-attachments/assets/23cc07d9-3a2d-48e8-a969-5b695b2cca1d" />


## Tests

Added two regression tests to `tests/test_list_search.py` (following the existing convention of driving the real action, then feeding the produced `ActionResult` into the view):

- `test_list_search_view_renders_list_id_result` — the `/info` single object is normalized and renders. Verified it fails without the fix.
- `test_list_search_view_renders_name_search_result` — the `/search` array passes through untouched.

Full suite: 73 passed.