### PR TITLE
docs: note 200-domain limit for leaked credentials search (RFPD-109762)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **on_poll_playbook_alert_type** | optional | string | Comma-separated list of Playbook alert types. (domain_abuse, cyber_vulnerability, code_repo_leakage are now supported) |
 **on_poll_playbook_alert_status** | optional | string | Comma-separated list of Playbook alert statuses. (New, InProgress, Dismissed, Resolved are now supported) |
 **on_poll_playbook_alert_start_time** | optional | string | Poll playbook alerts created after (date in ISO format: 2022-12-01T11:00:00+00) |
-**on_poll_leaked_credentials_domains** | optional | string | Comma-separated list of domains to be searched for leaked credentials. You consent to pulling and storing identity and credential data in the system. |
+**on_poll_leaked_credentials_domains** | optional | string | Comma-separated list of domains to be searched for leaked credentials (maximum 200 domains). You consent to pulling and storing identity and credential data in the system. |
 **on_poll_leaked_credentials_novel_only** | optional | boolean | Only return novel credentials |
 **on_poll_leaked_credentials_created_after** | optional | string | Poll leaked credentials created after this date (ISO format: 2022-12-01T11:00:00+00) |
 
@@ -1992,7 +1992,7 @@ Read only: **True**
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **organization_id** | optional | Comma-separated list of Organization IDs to filter detections | string | `recordedfuture organization id` |
-**domains** | required | Comma-separated list of domains to search for detections | string | `domain` |
+**domains** | required | Comma-separated list of domains to search for detections (maximum 200 domains) | string | `domain` |
 **novel_only** | optional | Only fetch novel detections (True/False) | boolean | |
 **detection_type** | optional | Type of detection to fetch | string | |
 **created_after** | optional | Detections created after this date (ISO 8601 format) | string | |

--- a/recordedfuture.json
+++ b/recordedfuture.json
@@ -145,7 +145,7 @@
         "on_poll_leaked_credentials_domains": {
             "data_type": "string",
             "order": 21,
-            "description": "Comma-separated list of domains to be searched for leaked credentials. You consent to pulling and storing identity and credential data in the system."
+            "description": "Comma-separated list of domains to be searched for leaked credentials (maximum 200 domains). You consent to pulling and storing identity and credential data in the system."
         },
         "ph9": {
             "data_type": "ph",
@@ -10303,7 +10303,7 @@
                     "order": 0
                 },
                 "domains": {
-                    "description": "Comma-separated list of domains to search for detections",
+                    "description": "Comma-separated list of domains to search for detections (maximum 200 domains)",
                     "data_type": "string",
                     "required": true,
                     "contains": [

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * List Search: Added `list_id` parameter to allow searching by list ID directly; deprecated the separate `list details` action.
+* Identity Leaked Credentials Search: Documented the 200-domain limit for the `domains` parameter.


### PR DESCRIPTION
## Summary
[RFPD-109762](https://recordedfuture.atlassian.net/browse/RFPD-109762): the upstream Identity API limit for the leaked-credentials domain search was raised from 10 to **200** domains. This PR surfaces that limit in the connector for transparency (per the ticket's remaining ask).

## Changes
- `recordedfuture.json`: added `(maximum 200 domains)` to the `domains` parameter description of the **identity leaked credentials search** action.
- `recordedfuture.json`: added the same note to the `on_poll_leaked_credentials_domains` on-poll config field.
- `release_notes/unreleased.md`: added a changelog entry.

## Notes
- Documentation-only; the limit itself is enforced upstream by the Identity API.
- `README.md` is auto-generated from the manifest and will be refreshed by the build pipeline.